### PR TITLE
Feature: Add `yarn.lock` file support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-project-bundle",
-  "version": "0.0.9",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-project-bundle",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "description": "A simple bundler for TypeScript projects using TypeScript project references.",
     "main": "build/index.js",
     "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,14 @@ export class TsBundler {
         await ensureDir(fullOutPath);
 
         await this.copyFile(path.join(fullPackagePath, "package.json"), path.join(fullOutPath, "package.json"));
-        await this.copyFile(path.join(fullPackagePath, "package-lock.json"), path.join(fullOutPath, "package-lock.json"));
+
+        const yarnLockFilePath = path.join(fullPackagePath, "yarn.lock");
+        const yarnLockExists = await pathExists(yarnLockFilePath);
+        if (yarnLockExists) {
+          await this.copyFile(yarnLockFilePath, path.join(fullOutPath, "yarn.lock"));
+        } else {
+          await this.copyFile(path.join(fullPackagePath, "package-lock.json"),path.join(fullOutPath, "package-lock.json"));
+        }
 
         const fullDistPath = path.join(fullPackagePath, packageTsConfig.compilerOptions.outDir);
         const fullOutDistPath = path.join(fullOutPath, packageTsConfig.compilerOptions.outDir);


### PR DESCRIPTION
## What's in this PR

I've added support for bundling the lock file of the `yarn` package manager, in addition to `npm`

- Added support for bundling `yarn.lock` if it exists 433474063831d965b376e345799bcf432b8d7856
- Bumped package version to `0.0.11` 3f5bab594c9c796957763da98cffae30a986efa3

