### PR TITLE
Fix: Crash when bundling packages with no lockfile

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,10 +110,13 @@ export class TsBundler {
         await this.copyFile(path.join(fullPackagePath, "package.json"), path.join(fullOutPath, "package.json"));
 
         const yarnLockFilePath = path.join(fullPackagePath, "yarn.lock");
+        const npmLockFilePath = path.join(fullPackagePath, "package-lock.json");
         const yarnLockExists = await pathExists(yarnLockFilePath);
+        const npmLockExists = await pathExists(npmLockFilePath);
+
         if (yarnLockExists) {
           await this.copyFile(yarnLockFilePath, path.join(fullOutPath, "yarn.lock"));
-        } else {
+        } else if (npmLockExists) {
           await this.copyFile(path.join(fullPackagePath, "package-lock.json"),path.join(fullOutPath, "package-lock.json"));
         }
 


### PR DESCRIPTION
## What's in this PR

- Added a check to only copy `package-lock.json` if it exists 4972424db777d0d5ed690ff9feff3f0eca731179

This will fix an issue where the bundling process will crash if there is no yarn or npm lock file in a package.

I ran into this issue while using a yarn workspace/monorepo, where some packages can intentionally have no lock file.
